### PR TITLE
Fixes for template#to_safe and file extension handling for non-tex files

### DIFF
--- a/lib/iona/processing.ex
+++ b/lib/iona/processing.ex
@@ -64,7 +64,7 @@ defmodule Iona.Processing do
     end
   end
 
-  @spec process_content(input :: Iona.Input, format :: Iona.supported_format_t, opts :: Iona.processing_opts) :: {:ok, Iona.Document.t} | {:error, binary}
+  @spec process_path(input :: Iona.Input, format :: Iona.supported_format_t, opts :: Iona.processing_opts) :: {:ok, Iona.Document.t} | {:error, binary}
   def process_path(input, format, opts) do
     with_temp fn directory ->
       input_path = input |> Iona.Input.path
@@ -80,8 +80,10 @@ defmodule Iona.Processing do
   defp do_process(input, format, opts, path) do
     processor = Keyword.get(opts, :processor, Keyword.get(Iona.Config.processors, format, nil))
     if processor do
-      output_path = String.replace(path, ~r/\.tex$/, ".#{format}")
-      basename = Path.basename(path, ".tex")
+      ext = Path.extname(path)
+      {:ok, regex} = Regex.compile("\\#{ext}$")
+      output_path = String.replace(path, regex, ".#{format}")
+      basename = Path.basename(path, ext)
       dirname = Path.dirname(path)
       preprocessors = Keyword.get(opts, :preprocess, Iona.Config.preprocess)
       case copy_includes(dirname, Iona.Input.included_files(input)) do

--- a/lib/iona/template/engine.ex
+++ b/lib/iona/template/engine.ex
@@ -61,7 +61,7 @@ defmodule Iona.Template.Engine do
     fallback = quote line: line, do: Iona.Template.Engine.to_iodata(other)
 
     # However ignore them for the generated clauses to avoid warnings
-    quote line: -1 do
+    quote line: 0 do
       case unquote(expr) do
         {:safe, data} -> data
         bin when is_binary(bin) -> Iona.Template.Engine.escape(bin)

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"briefly": {:hex, :briefly, "0.3.0"},
-  "earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.8.4"},
-  "porcelain": {:hex, :porcelain, "2.0.0"}}
+%{"briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], []},
+  "earmark": {:hex, :earmark, "0.1.17", "a2269e72ff85501bdb58c2de9edc0a9a17a4be2757883eed1f601b30494ed2bf", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.8.4", "c74a30b09627ff22a2bb7f75d3b75dec3aedb2bd434bb3009a73a40425c2315d", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "porcelain": {:hex, :porcelain, "2.0.0", "fa0afbdb62eb006876c5f26455494c83fe19be754f0a8f417fdad25ffef947b1", [:mix], []}}


### PR DESCRIPTION
Iona.Processing
- Fixed spec line for process_path
- Updated do_process to use extension of input file when computing output path. The code assumed a '.tex' extension, which created problems if one had a pre-processor that used a different extension, like .Rnw for knitr.

Iona.Template.Engine
Changed `line: -1` to `line: 0` to work on OTP 19. Should probably investigate using `generated: true` and the effect that would have on backward compatibility.  See comment by josevalim on this issue: https://github.com/elixir-lang/elixir/issues/4617
