### PR TITLE
Update for compatibility with Erlang 19.2 and Elixir 1.4.2

### DIFF
--- a/lib/iona/processing.ex
+++ b/lib/iona/processing.ex
@@ -22,13 +22,13 @@ defmodule Iona.Processing do
     if supported_format?(format) do
       format
     else
-      raise UnsupportedFormat, message: (format |> to_string)
+      raise UnsupportedFormatError, message: (format |> to_string)
     end
   end
 
   @spec supported_format?(format :: Iona.supported_format_t) :: boolean
   defp supported_format?(format) do
-    Enum.member?(supported_formats, format)
+    Enum.member?(supported_formats(), format)
   end
 
   @spec parse_format(path :: Path.t) :: nil | atom

--- a/lib/iona/template/engine.ex
+++ b/lib/iona/template/engine.ex
@@ -81,6 +81,9 @@ defmodule Iona.Template.Engine do
   defp handle_assign(arg), do: arg
 
   @doc false
+  def fetch_assign(assigns, key) when is_map(assigns) do
+    fetch_assign(Map.to_list(assigns), key)
+  end
   def fetch_assign(assigns, key) do
     case Keyword.fetch(assigns, key) do
       :error ->

--- a/lib/iona/template/engine.ex
+++ b/lib/iona/template/engine.ex
@@ -61,7 +61,7 @@ defmodule Iona.Template.Engine do
     fallback = quote line: line, do: Iona.Template.Engine.to_iodata(other)
 
     # However ignore them for the generated clauses to avoid warnings
-    quote line: -1 do
+    quote line: :keep do
       case unquote(expr) do
         {:safe, data} -> data
         bin when is_binary(bin) -> Iona.Template.Engine.escape(bin)
@@ -82,10 +82,10 @@ defmodule Iona.Template.Engine do
 
   @doc false
   def fetch_assign(assigns, key) do
-    case Dict.fetch(assigns, key) do
+    case Keyword.fetch(assigns, key) do
       :error ->
         raise ArgumentError, message: """
-        assign @#{key} not available in eex template. Available assigns: #{inspect Dict.keys(assigns)}
+        assign @#{key} not available in eex template. Available assigns: #{inspect Keyword.keys(assigns)}
         """
       {:ok, val} -> val
     end

--- a/lib/iona/template/helper.ex
+++ b/lib/iona/template/helper.ex
@@ -34,9 +34,9 @@ defmodule Iona.Template.Helper do
   end
   def escape(text) when is_binary(text) do
     @replace
-    |> Enum.reduce text, fn ({pattern, replacement}, memo) ->
+    |> Enum.reduce(text, fn ({pattern, replacement}, memo) ->
       memo |> String.replace(pattern, replacement)
-    end
+    end)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule Iona.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      dialyzer: [flags: "--fullpath"],
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application
@@ -19,7 +19,7 @@ defmodule Iona.Mixfile do
   def application do
     [applications: [:logger, :briefly, :porcelain],
      mod: {Iona, []},
-     env: default_env]
+     env: default_env()]
   end
 
   # Dependencies can be Hex packages:

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"briefly": {:hex, :briefly, "0.3.0"},
-  "earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.8.4"},
-  "porcelain": {:hex, :porcelain, "2.0.0"}}
+%{"briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], []},
+  "earmark": {:hex, :earmark, "0.1.17", "a2269e72ff85501bdb58c2de9edc0a9a17a4be2757883eed1f601b30494ed2bf", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.8.4", "c74a30b09627ff22a2bb7f75d3b75dec3aedb2bd434bb3009a73a40425c2315d", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "porcelain": {:hex, :porcelain, "2.0.0", "fa0afbdb62eb006876c5f26455494c83fe19be754f0a8f417fdad25ffef947b1", [:mix], []}}

--- a/test/lib/iona_test.exs
+++ b/test/lib/iona_test.exs
@@ -43,8 +43,15 @@ defmodule Test.Iona do
     assert String.starts_with?(out, "%PDF")
   end
 
-  test "template simple interpolation" do
+  test "template simple interpolation from a keyword list" do
     out = [name: "Squash", items: ~w(Acorn Summer Spaghetti)]
+    |> Iona.template(path: @items_template)
+    |> Iona.to!(:pdf)
+    assert String.starts_with?(out, "%PDF")
+  end
+
+  test "template simple interpolation from a map" do
+    out = %{name: "Squash", items: ~w(Acorn Summer Spaghetti)}
     |> Iona.template(path: @items_template)
     |> Iona.to!(:pdf)
     assert String.starts_with?(out, "%PDF")


### PR DESCRIPTION
Fix most compiler warnings and an issue that was causing tests to fail in the latest Erlang/Elixir. Specifically:

- Added parens to zero-arity function calls to silence compiler warnings.
- Fixed what I assume was a typo and changed `UnsupportedFormat` to `UnsupportedFormatError`.
- Changed `quote line: -1` to `quote line: :keep` as is the updated syntax.
- Used `Keyword` module functions instead of deprecated `Dict` module functions when working with keyword lists.
- Added parens around function call in pipeline to silence compiler warning.

Should resolve issue #5 